### PR TITLE
Make application:didFinishLaunchingWithOptions: open

### DIFF
--- a/PluggableApplicationDelegate.podspec
+++ b/PluggableApplicationDelegate.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PluggableApplicationDelegate'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'Services oriented AppDelegate in Swift 3.'
   s.description      = <<-DESC
 PluggableApplicationDelegate is a way of decoupling AppDelegate, by splitting it into small modules called ApplicationService.

--- a/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
+++ b/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
@@ -44,7 +44,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 3.0, *)
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         for service in __services {
             if let serviceResult = service.application?(application, didFinishLaunchingWithOptions: launchOptions) {
                 if serviceResult == false {


### PR DESCRIPTION
To be able to set `window` and the `rootViewController` via code, at least `application:didFinishLaunchingWithOptions` of `PluggableApplicationDelegate` needs to be defined as `open`.