### PR TITLE
Remove `:git =>` from the podfile installation string

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ PluggableApplicationDelegate is available through [CocoaPods](http://cocoapods.o
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod "PluggableApplicationDelegate", :git => "https://github.com/fmo91/PluggableApplicationDelegate"
+pod 'PluggableApplicationDelegate'
 ```
 
 ## Author


### PR DESCRIPTION
`:git =>`should not be included in the installation, since it will always take the top of master instead of the last release. It also will update the pod every time `pod update` is executed, resulting in something like:

`Installing PluggableApplicationDelegate 0.1.2 (was 0.1.2)`

Causing `-Dirty` states with some CI configurations