### PR TITLE
Fix delegate method handling

### DIFF
--- a/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
+++ b/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
@@ -18,7 +18,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     public var window: UIWindow?
     
     open var services: [ApplicationService] { return [] }
-    private lazy var __services: [ApplicationService]! = {
+    private lazy var __services: [ApplicationService] = {
         return self.services
     }()
     
@@ -30,18 +30,24 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     @available(iOS 6.0, *)
     public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
-        
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? true)
+        var result = false
+        for service in __services {
+            if service.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS 3.0, *)
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
-
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? true)
+        var result = false
+        for service in __services {
+            if service.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     
@@ -61,23 +67,35 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     @available(iOS, introduced: 2.0, deprecated: 9.0, message: "Please use application:openURL:options:")
     public func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(application, handleOpen: url) ?? true)
+        var result = false
+        for service in __services {
+            if service.application?(application, handleOpen: url) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS, introduced: 4.2, deprecated: 9.0, message: "Please use application:openURL:options:")
-    public func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(application, open: url, sourceApplication: sourceApplication, annotation: annotation) ?? true)
+    public func application(_ application: UIApplication, public url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+        var result = false
+        for service in __services {
+            if service.application?(application, open: url, sourceApplication: sourceApplication, annotation: annotation) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS 9.0, *)
-    public func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(app, open: url, options: options) ?? true)
+    public func application(_ app: UIApplication, public url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+        var result = false
+        for service in __services {
+            if service.application?(app, open: url, options: options) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS 2.0, *)
@@ -304,9 +322,13 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // If unimplemented, the default behavior is to allow the extension point identifier.
     @available(iOS 8.0, *)
     public func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
-        return __services.reduce(true) { (previous, service) -> Bool in
-            previous && (service.application?(application, shouldAllowExtensionPointIdentifier: extensionPointIdentifier) ?? true)
+        var result = false
+        for service in __services {
+            if service.application?(application, shouldAllowExtensionPointIdentifier: extensionPointIdentifier) ?? true {
+                result = true
+            }
         }
+        return result
     }
     
     
@@ -323,16 +345,24 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     @available(iOS 6.0, *)
     public func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {
-        return __services.reduce(false) { (previous, service) -> Bool in
-            previous || (service.application?(application, shouldSaveApplicationState: coder) ?? false)
+        var result = false
+        for service in __services {
+            if service.application?(application, shouldSaveApplicationState: coder) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS 6.0, *)
     public func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
-        return __services.reduce(false) { (previous, service) -> Bool in
-            previous || (service.application?(application, shouldRestoreApplicationState: coder) ?? false)
+        var result = false
+        for service in __services {
+            if service.application?(application, shouldRestoreApplicationState: coder) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     @available(iOS 6.0, *)
@@ -356,9 +386,13 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // or application:didFailToContinueUserActivityWithType:error: if an error was encountered.
     @available(iOS 8.0, *)
     public func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
-        return __services.reduce(false) { (previous, service) -> Bool in
-            previous || (service.application?(application, willContinueUserActivityWithType: userActivityType) ?? false)
+        var result = false
+        for service in __services {
+            if service.application?(application, willContinueUserActivityWithType: userActivityType) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     
@@ -368,9 +402,13 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // restoreUserActivityState on all objects.
     @available(iOS 8.0, *)
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Swift.Void) -> Bool {
-        return __services.reduce(false) { (previous, service) -> Bool in
-            previous || (service.application?(application, continue: userActivity, restorationHandler: restorationHandler) ?? false)
+        var result = false
+        for service in __services {
+            if service.application?(application, continue: userActivity, restorationHandler: restorationHandler) ?? false {
+                result = true
+            }
         }
+        return result
     }
     
     


### PR DESCRIPTION
This fixes #14.

The issue in the original code is that while `reduce` *will* go over each and all services, the Swift boolean operators implement [short-circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) which prevents some delegate methods to be called properly (i.e. given `a && b`, if `a` is `false`, `b` is not evaluated. Same thing for `||` and `true`).

This PR also reverses the logic on how to return `true` or `false`: the current code says _If all delegate methods return `true`, then return `true`. Otherwise returns `false`_
But since the service will most likely be targeted for a specific purpose, most probably only one will for example handle a user activity and a url (and thus might return `true`), while others might just responds to state changes (and thus return `false`), so this changes the logic to _If at least one delegate methods return `true`, then return `true`. Otherwise returns `false`_
In that case, `true` should still be returned to iOS.