### PR TITLE
Set window property on ApplicationService when defined

### DIFF
--- a/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
+++ b/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
@@ -13,6 +13,12 @@ import CloudKit
 /// It doesn't add more functionalities yet.
 public protocol ApplicationService: UIApplicationDelegate {}
 
+extension ApplicationService {
+    public var window: UIWindow? {
+        return UIApplication.shared.delegate?.window ?? nil
+    }
+}
+
 open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     public var window: UIWindow?


### PR DESCRIPTION
This allows to access the `window` property of your classes implemented `ApplicationService`, as you would originally with a classic class that implements `UIApplicationDelegate`.