### PR TITLE
Changed lifecycle methods from public to open

### DIFF
--- a/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
+++ b/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
@@ -23,13 +23,13 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }()
     
     @available(iOS 2.0, *)
-    public func applicationDidFinishLaunching(_ application: UIApplication) {
+    open func applicationDidFinishLaunching(_ application: UIApplication) {
         __services.forEach { $0.applicationDidFinishLaunching?(application) }
     }
     
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, willFinishLaunchingWithOptions: launchOptions) ?? false {
@@ -40,7 +40,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 3.0, *)
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+    open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, didFinishLaunchingWithOptions: launchOptions) ?? false {
@@ -52,21 +52,21 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 2.0, *)
-    public func applicationDidBecomeActive(_ application: UIApplication) {
+    open func applicationDidBecomeActive(_ application: UIApplication) {
         for service in __services {
             service.applicationDidBecomeActive?(application)
         }
     }
     
     @available(iOS 2.0, *)
-    public func applicationWillResignActive(_ application: UIApplication) {
+    open func applicationWillResignActive(_ application: UIApplication) {
         for service in __services {
             service.applicationWillResignActive?(application)
         }
     }
     
     @available(iOS, introduced: 2.0, deprecated: 9.0, message: "Please use application:openURL:options:")
-    public func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
+    open func application(_ application: UIApplication, handleOpen url: URL) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, handleOpen: url) ?? false {
@@ -77,7 +77,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS, introduced: 4.2, deprecated: 9.0, message: "Please use application:openURL:options:")
-    public func application(_ application: UIApplication, public url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    open func application(_ application: UIApplication, public url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, open: url, sourceApplication: sourceApplication, annotation: annotation) ?? false {
@@ -88,7 +88,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 9.0, *)
-    public func application(_ app: UIApplication, public url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    open func application(_ app: UIApplication, public url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         var result = false
         for service in __services {
             if service.application?(app, open: url, options: options) ?? false {
@@ -99,21 +99,21 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 2.0, *)
-    public func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
+    open func applicationDidReceiveMemoryWarning(_ application: UIApplication) {
         for service in __services {
             service.applicationDidReceiveMemoryWarning?(application)
         }
     }
     
     @available(iOS 2.0, *)
-    public func applicationWillTerminate(_ application: UIApplication) {
+    open func applicationWillTerminate(_ application: UIApplication) {
         for service in __services {
             service.applicationWillTerminate?(application)
         }
     }
     
     @available(iOS 2.0, *)
-    public func applicationSignificantTimeChange(_ application: UIApplication)  {
+    open func applicationSignificantTimeChange(_ application: UIApplication)  {
         for service in __services {
             service.applicationSignificantTimeChange?(application)
         }
@@ -121,26 +121,26 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 2.0, *)
-    public func application(_ application: UIApplication, willChangeStatusBarOrientation newStatusBarOrientation: UIInterfaceOrientation, duration: TimeInterval) {
+    open func application(_ application: UIApplication, willChangeStatusBarOrientation newStatusBarOrientation: UIInterfaceOrientation, duration: TimeInterval) {
         for service in __services {
             service.application?(application, willChangeStatusBarOrientation: newStatusBarOrientation, duration: duration)
         }
     }
     
     @available(iOS 2.0, *)
-    public func application(_ application: UIApplication, didChangeStatusBarOrientation oldStatusBarOrientation: UIInterfaceOrientation) {
+    open func application(_ application: UIApplication, didChangeStatusBarOrientation oldStatusBarOrientation: UIInterfaceOrientation) {
         for service in __services {
             service.application?(application, didChangeStatusBarOrientation: oldStatusBarOrientation)
         }
     }
     
-//    public func application(_ application: UIApplication, willChangeStatusBarFrame newStatusBarFrame: CGRect) {
+//    open func application(_ application: UIApplication, willChangeStatusBarFrame newStatusBarFrame: CGRect) {
 //        for service in __services {
 //            service.application?(application, willChangeStatusBarFrame: newStatusBarFrame)
 //        }
 //    }
 //
-//    public func application(_ application: UIApplication, didChangeStatusBarFrame oldStatusBarFrame: CGRect) {
+//    open func application(_ application: UIApplication, didChangeStatusBarFrame oldStatusBarFrame: CGRect) {
 //        for service in __services {
 //            service.application?(application, didChangeStatusBarFrame: oldStatusBarFrame)
 //        }
@@ -149,7 +149,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     // This callback will be made upon calling -[UIApplication registerUserNotificationSettings:]. The settings the user has granted to the application will be passed in as the second argument.
     @available(iOS, introduced: 8.0, deprecated: 10.0, message: "Use UserNotification UNNotification Settings instead")
-    public func application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
+    open func application(_ application: UIApplication, didRegister notificationSettings: UIUserNotificationSettings) {
         for service in __services {
             service.application?(application, didRegister: notificationSettings)
         }
@@ -157,7 +157,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 3.0, *)
-    public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    open func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         for service in __services {
             service.application?(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
         }
@@ -165,7 +165,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 3.0, *)
-    public func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    open func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         for service in __services {
             service.application?(application, didFailToRegisterForRemoteNotificationsWithError: error)
         }
@@ -173,7 +173,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS, introduced: 3.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate willPresentNotification:withCompletionHandler:] or -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:] for user visible notifications and -[UIApplicationDelegate application:didReceiveRemoteNotification:fetchCompletionHandler:] for silent remote notifications")
-    public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
+    open func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any]) {
         for service in __services {
             service.application?(application, didReceiveRemoteNotification: userInfo)
         }
@@ -181,7 +181,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS, introduced: 4.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate willPresentNotification:withCompletionHandler:] or -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:]")
-    public func application(_ application: UIApplication, didReceive notification: UILocalNotification) {
+    open func application(_ application: UIApplication, didReceive notification: UILocalNotification) {
         for service in __services {
             service.application?(application, didReceive: notification)
         }
@@ -192,7 +192,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // A nil action identifier indicates the default action.
     // You should call the completion handler as soon as you've finished handling the action.
     @available(iOS, introduced: 8.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:]")
-    public func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, for notification: UILocalNotification, completionHandler: @escaping () -> Swift.Void) {
+    open func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, for notification: UILocalNotification, completionHandler: @escaping () -> Swift.Void) {
         
         for service in __services {
             service.application?(application, handleActionWithIdentifier: identifier, for: notification, completionHandler: completionHandler)
@@ -202,7 +202,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS, introduced: 9.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:]")
-    public func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
+    open func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
         for service in __services {
             service.application?(application, handleActionWithIdentifier: identifier, forRemoteNotification: userInfo, withResponseInfo: responseInfo, completionHandler: completionHandler)
         }
@@ -213,7 +213,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // A nil action identifier indicates the default action.
     // You should call the completion handler as soon as you've finished handling the action.
     @available(iOS, introduced: 8.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:]")
-    public func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
+    open func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, forRemoteNotification userInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
         for service in __services {
             service.application?(application, handleActionWithIdentifier: identifier, forRemoteNotification: userInfo, completionHandler: completionHandler)
         }
@@ -221,7 +221,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS, introduced: 9.0, deprecated: 10.0, message: "Use UserNotifications Framework's -[UNUserNotificationCenterDelegate didReceiveNotificationResponse:withCompletionHandler:]")
-    public func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, for notification: UILocalNotification, withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
+    open func application(_ application: UIApplication, handleActionWithIdentifier identifier: String?, for notification: UILocalNotification, withResponseInfo responseInfo: [AnyHashable : Any], completionHandler: @escaping () -> Swift.Void) {
         for service in __services {
             service.application?(application, handleActionWithIdentifier: identifier, for: notification, withResponseInfo: responseInfo, completionHandler: completionHandler)
         }
@@ -232,7 +232,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
      
      This method will be invoked even if the application was launched or resumed because of the remote notification. The respective delegate methods will be invoked first. Note that this behavior is in contrast to application:didReceiveRemoteNotification:, which is not called in those cases, and which will not be invoked if this method is implemented. !*/
     @available(iOS 7.0, *)
-    public func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
+    open func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
         for service in __services {
             service.application?(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
         }
@@ -241,7 +241,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     /// Applications with the "fetch" background mode may be given opportunities to fetch updated content in the background or when it is convenient for the system. This method will be called in these situations. You should call the fetchCompletionHandler as soon as you're finished performing that operation, so the system can accurately estimate its power and data cost.
     @available(iOS 7.0, *)
-    public func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
+    open func application(_ application: UIApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Swift.Void) {
         for service in __services {
             service.application?(application, performFetchWithCompletionHandler: completionHandler)
         }
@@ -251,7 +251,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // Called when the user activates your application by selecting a shortcut on the home screen,
     // except when -application:willFinishLaunchingWithOptions: or -application:didFinishLaunchingWithOptions returns NO.
     @available(iOS 9.0, *)
-    public func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Swift.Void) {
+    open func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Swift.Void) {
         for service in __services {
             service.application?(application, performActionFor: shortcutItem, completionHandler: completionHandler)
         }
@@ -264,7 +264,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // callbacks. If such a session has already been created (if the app is being resumed, for instance), then the delegate will start receiving
     // callbacks without any action by the application. You should call the completionHandler as soon as you're finished handling the callbacks.
     @available(iOS 7.0, *)
-    public func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Swift.Void) {
+    open func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Swift.Void) {
         for service in __services {
             service.application?(application, handleEventsForBackgroundURLSession: identifier, completionHandler: completionHandler)
         }
@@ -272,7 +272,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 8.2, *)
-    public func application(_ application: UIApplication, handleWatchKitExtensionRequest userInfo: [AnyHashable : Any]?, reply: @escaping ([AnyHashable : Any]?) -> Swift.Void) {
+    open func application(_ application: UIApplication, handleWatchKitExtensionRequest userInfo: [AnyHashable : Any]?, reply: @escaping ([AnyHashable : Any]?) -> Swift.Void) {
         for service in __services {
             service.application?(application, handleWatchKitExtensionRequest: userInfo, reply: reply)
         }
@@ -280,7 +280,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 9.0, *)
-    public func applicationShouldRequestHealthAuthorization(_ application: UIApplication) {
+    open func applicationShouldRequestHealthAuthorization(_ application: UIApplication) {
         for service in __services {
             service.applicationShouldRequestHealthAuthorization?(application)
         }
@@ -288,14 +288,14 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 4.0, *)
-    public func applicationDidEnterBackground(_ application: UIApplication) {
+    open func applicationDidEnterBackground(_ application: UIApplication) {
         for service in __services {
             service.applicationDidEnterBackground?(application)
         }
     }
     
     @available(iOS 4.0, *)
-    public func applicationWillEnterForeground(_ application: UIApplication) {
+    open func applicationWillEnterForeground(_ application: UIApplication) {
         for service in __services {
             service.applicationWillEnterForeground?(application)
         }
@@ -303,14 +303,14 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 4.0, *)
-    public func applicationProtectedDataWillBecomeUnavailable(_ application: UIApplication) {
+    open func applicationProtectedDataWillBecomeUnavailable(_ application: UIApplication) {
         for service in __services {
             service.applicationProtectedDataWillBecomeUnavailable?(application)
         }
     }
     
     @available(iOS 4.0, *)
-    public func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {
+    open func applicationProtectedDataDidBecomeAvailable(_ application: UIApplication) {
         for service in __services {
             service.applicationProtectedDataDidBecomeAvailable?(application)
         }
@@ -321,7 +321,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // Constants representing common extension point identifiers are provided further down.
     // If unimplemented, the default behavior is to allow the extension point identifier.
     @available(iOS 8.0, *)
-    public func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
+    open func application(_ application: UIApplication, shouldAllowExtensionPointIdentifier extensionPointIdentifier: UIApplicationExtensionPointIdentifier) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, shouldAllowExtensionPointIdentifier: extensionPointIdentifier) ?? true {
@@ -333,7 +333,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, viewControllerWithRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+    open func application(_ application: UIApplication, viewControllerWithRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
         for service in __services {
             if let viewController = service.application?(application, viewControllerWithRestorationIdentifierPath: identifierComponents, coder: coder) {
                 return viewController
@@ -344,7 +344,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {
+    open func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, shouldSaveApplicationState: coder) ?? false {
@@ -355,7 +355,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
+    open func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, shouldRestoreApplicationState: coder) ?? false {
@@ -366,14 +366,14 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, willEncodeRestorableStateWith coder: NSCoder) {
+    open func application(_ application: UIApplication, willEncodeRestorableStateWith coder: NSCoder) {
         for service in __services {
             service.application?(application, willEncodeRestorableStateWith: coder)
         }
     }
     
     @available(iOS 6.0, *)
-    public func application(_ application: UIApplication, didDecodeRestorableStateWith coder: NSCoder) {
+    open func application(_ application: UIApplication, didDecodeRestorableStateWith coder: NSCoder) {
         for service in __services {
             service.application?(application, didDecodeRestorableStateWith: coder)
         }
@@ -385,7 +385,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // For each application:willContinueUserActivityWithType: invocation, you are guaranteed to get exactly one invocation of application:continueUserActivity: on success,
     // or application:didFailToContinueUserActivityWithType:error: if an error was encountered.
     @available(iOS 8.0, *)
-    public func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
+    open func application(_ application: UIApplication, willContinueUserActivityWithType userActivityType: String) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, willContinueUserActivityWithType: userActivityType) ?? false {
@@ -401,7 +401,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // invoked with the user activity. Invoking the restorationHandler is optional. It may be copied and invoked later, and it will bounce to the main thread to complete its work and call
     // restoreUserActivityState on all objects.
     @available(iOS 8.0, *)
-    public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Swift.Void) -> Bool {
+    open func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Swift.Void) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, continue: userActivity, restorationHandler: restorationHandler) ?? false {
@@ -414,7 +414,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     // If the user activity cannot be fetched after willContinueUserActivityWithType is called, this will be called on the main thread when implemented.
     @available(iOS 8.0, *)
-    public func application(_ application: UIApplication, didFailToContinueUserActivityWithType userActivityType: String, error: Error) {
+    open func application(_ application: UIApplication, didFailToContinueUserActivityWithType userActivityType: String, error: Error) {
         for service in __services {
             service.application?(application, didFailToContinueUserActivityWithType: userActivityType, error: error)
         }
@@ -423,7 +423,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     
     // This is called on the main thread when a user activity managed by UIKit has been updated. You can use this as a last chance to add additional data to the userActivity.
     @available(iOS 8.0, *)
-    public func application(_ application: UIApplication, didUpdate userActivity: NSUserActivity) {
+    open func application(_ application: UIApplication, didUpdate userActivity: NSUserActivity) {
         for service in __services {
             service.application?(application, didUpdate: userActivity)
         }
@@ -434,7 +434,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     // You should use the CKShareMetadata object's shareURL and containerIdentifier to schedule a CKAcceptSharesOperation, then start using
     // the resulting CKShare and its associated record(s), which will appear in the CKContainer's shared database in a zone matching that of the record's owner.
     @available(iOS 10.0, *)
-    public func application(_ application: UIApplication, userDidAcceptCloudKitShareWith cloudKitShareMetadata: CKShareMetadata) {
+    open func application(_ application: UIApplication, userDidAcceptCloudKitShareWith cloudKitShareMetadata: CKShareMetadata) {
         for service in __services {
             service.application?(application, userDidAcceptCloudKitShareWith: cloudKitShareMetadata)
         }


### PR DESCRIPTION
My company is using PluggableApplicationDelegate in our iOS codebase. We'd like to time each ApplicationService's didFinishLaunching and didBecomeActive methods, to find where we can get performance gains. My initial thought was to subclass PluggableApplicationDelegate and add timers to the relevant methods, but because they're public (not open) this isn't possible.

This will weaken access control, but I think anyone who's interested in subclassing PluggableApplicationDelegate should be fine - as long as you call the superclass method.