### PR TITLE
Bugfix: open URL method was broken.

### DIFF
--- a/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
+++ b/PluggableApplicationDelegate/Classes/ApplicationServicesManager.swift
@@ -77,7 +77,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS, introduced: 4.2, deprecated: 9.0, message: "Please use application:openURL:options:")
-    open func application(_ application: UIApplication, public url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    open func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
         var result = false
         for service in __services {
             if service.application?(application, open: url, sourceApplication: sourceApplication, annotation: annotation) ?? false {
@@ -88,7 +88,7 @@ open class PluggableApplicationDelegate: UIResponder, UIApplicationDelegate {
     }
     
     @available(iOS 9.0, *)
-    open func application(_ app: UIApplication, public url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    open func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         var result = false
         for service in __services {
             if service.application?(app, open: url, options: options) ?? false {


### PR DESCRIPTION
For details, see https://github.com/fmo91/PluggableApplicationDelegate/issues/20 - bug in a previous commit renamed the application openURL method, so its argument (previously 'open') was changed to 'public'. This fixes it.

I've tested it on my company's AppDelegate (which inherits from PluggableApplicationDelegate and it worked in our codebase.